### PR TITLE
Fix python version at <3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "mtqe", from="src"}]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<4.0.0"
+python = ">=3.9,<3.11.0"
 ipywidgets = "^8.1.1"
 jupyter = "^1.0.0"
 matplotlib = "^3.8.0"


### PR DESCRIPTION
I got the following error when running the data preprocessing scripts on a MacBook with M3:

```bash
ModuleNotFoundError: No module named 'sklearn'
```

Based on advice I found online I solved this by using Python 3.10 instead of my default 3.12. Admittedly I have not tested whether Python 3.11 works.